### PR TITLE
[WIP] Update entry for Quantify

### DIFF
--- a/projects/quantify.md
+++ b/projects/quantify.md
@@ -9,8 +9,24 @@ tags:
   - python
   - pulse-level
   - control-hardware-backends
-  - Data acquisition
+  - data-acquisition
   - QCoDeS
+  - gitlab
+bounties:
+  - name: Create a jupyter-lab extension for realtime visualization
+    issue_url: https://gitlab.com/quantify-os/quantify-core/-/issues/203
+    value: 100
+  - name: Create an interactive data browser
+    issue_url: https://gitlab.com/quantify-os/quantify-core/-/issues/204
+    value: 100
 ---
 
-Quantify enables quantum computing users to program pulse-level physics experiments in a hardware-agnostic manner (currently supporting Qblox and Zurich Instruments control hardware) through `quantify-scheduler` (https://gitlab.com/quantify-os/quantify-scheduler), and to automate data acquisition and execution of these experiments with `quantify-core` (https://gitlab.com/quantify-os/quantify-core).
+Quantify enables quantum computing users to program `pulse-level` physics experiments  
+- in a hardware-agnostic manner through [`quantify-scheduler`](https://gitlab.com/quantify-os/quantify-scheduler) (currently supporting Qblox and Zurich Instruments `control hardware`), 
+- and to automate `data acquisition` and execution of these experiments with [`quantify-core`](https://gitlab.com/quantify-os/quantify-core).
+
+
+Documentation: [quantify-core](https://quantify-quantify-core.readthedocs-hosted.com/) | [quantify-scheduler](https://quantify-quantify-scheduler.readthedocs-hosted.com/) | [intro video](https://www.youtube.com/embed/koWIp12hD8Q?start=150&end=1126)
+
+
+> General issues on GitLab we are looking for help with during [`unitaryhack`](https://gitlab.com/groups/quantify-os/-/issues?label_name[]=unitaryhack).


### PR DESCRIPTION
Dear Sarah and Nathan,

Updating our entry for UH and adding bounties. Added `[WIP]` as we still need to add the remaining issue to get to full bounty amount.

**Question/request** In using GitLab as well as child repos under main project, our links are formatted as 
```https://gitlab.com/quantify-os/quantify-[core|scheduler]/-/issues/[issue_num]```
- this is not compatible with how issue links are auto generated I expect
- I've added `issue_url` key as placeholder, please suggest how to proceed

Thanks!

Edgar - on behalf of the Quantify maintainers
