### PR TITLE
Bounties for PennyLane, extend project description

### DIFF
--- a/projects/pennylane.md
+++ b/projects/pennylane.md
@@ -10,6 +10,22 @@ tags:
   - qml
   - quantum-chemistry
   - quantum-computing
+bounties:
+  - name: Add SPSA optimization method
+    issue_num: 2451
+    value: 125
+  - name: Function for determining Operator equality
+    issue_num: 2552
+    value: 75
+  - name: Request for new matplotlib drawing styles
+    issue_num: 2555
+    value: 2x25
+  - name: Adding IsingXY operation
+    issue_num: 2559
+    value: 25
+  - name: Add a `requirements_dev.txt` file
+    issue_num: 2560
+    value: 25
 ---
 
 

--- a/projects/pennylane.md
+++ b/projects/pennylane.md
@@ -32,3 +32,9 @@ bounties:
 PennyLane is a cross-platform Python library for differentiable programming of quantum computers.
 
 Train a quantum computer the same way as a neural network.
+
+For more details about PennyLane, visit the [PennyLane website](https://pennylane.ai), the [PennyLane docs](https://pennylane.readthedocs.io), or the [PennyLane GitHub repository](https://github.com/PennyLaneAI/pennylane).
+
+For more details about contributing to PennyLane, you can also check out our [contributions page](https://github.com/PennyLaneAI/pennylane/blob/master/.github/CONTRIBUTING.md) and our [developer hub](https://pennylane.readthedocs.io/en/stable/development/guide.html). Feel free to ask questions on [GitHub](https://github.com/PennyLaneAI/pennylane), our [discussion forum](https://discuss.pennylane.ai/), or on [Slack](https://u.strawberryfields.ai/slack/).
+
+All contributors to PennyLane will be listed as authors on the releases.


### PR DESCRIPTION
Hi @nathanshammah,

We would like to
* Add the bounty issues for PennyLane;
* Extend the description of PennyLane with links to the website, forum and Slack channel

in this PR. Let us know if something would need adjustments.