### PR TITLE
replace citation issue

### DIFF
--- a/projects/mitiq.md
+++ b/projects/mitiq.md
@@ -11,8 +11,8 @@ tags:
   - run-on-hardware
   - python
 bounties:
-  - name: Redundant information in citation file
-    issue_num: 1227
+  - name: Add thumbnail images to documentation examples
+    issue_num: 1283
     value: 50
   - name: Use consistent citation style in docs and function doctrings.
     issue_num: 1250


### PR DESCRIPTION
I stole the [citation issue](https://github.com/unitaryfund/mitiq/issues/1227) before unitaryhack is getting started, so as per @andreamari's [recommendation](https://github.com/unitaryfund/mitiq/pull/1299#pullrequestreview-978517425), replacing it with unitaryfund/mitiq#1283.