### PR TITLE
#75: Show closed bounties on project pages

### DIFF
--- a/_includes/layouts/project.njk
+++ b/_includes/layouts/project.njk
@@ -10,14 +10,22 @@ section: project
     <a href = {{project_url}}>{{ title }}</a></h1>
 
   <strong>Open bounties:</strong>
-  {% if bounties %}
-  <ul style="list-style-type:square">
-    {% for issue in bounties %}         
-      {% set issueUrl %}{{project_url}}/issues/{{issue.issue_num}}{% endset %}
-      <li><a class="tag" href="{{ issueUrl | url }}" rel="issue">${{ issue.value }} | {{issue.name}}</a></li>
-    {% endfor %}
-  </ul>
-  {% endif %}
+  {% for scraped_project in gh.projects %}
+      {% if scraped_project.title === title %}
+          {% if scraped_project.bounties %}
+              <ul style="list-style-type:square">
+              {% for issue in scraped_project.bounties %}
+                  {% set issueUrl %}{{project_url}}/issues/{{issue.issue_num}}{% endset %}
+                  {% if issue.state == "closed" %}
+                      <li><a class="tag" href="{{ issueUrl | url }}" rel="issue" style="text-decoration:line-through;">${{ issue.value }} | {{issue.name}}</a></li>
+                  {% else %}
+                      <li><a class="tag" href="{{ issueUrl | url }}" rel="issue">${{ issue.value }} | {{issue.name}}</a></li>
+                  {% endif %}
+              {% endfor %}
+              </ul>
+          {% endif %}
+      {% endif %}
+  {% endfor %}
   <hr>
   {{ layoutContent | safe }}
   <nav>


### PR DESCRIPTION
This is the "quick-and-dirty, whatever-works" fix for issue #75.

The project layout metadata do not contain information scraped from GitHub. However, these GitHub metadata are available in the context of that layout, already. Without being overly clever or concerned for the long-term maintainability of the event app, all we have to do is iterate over the GitHub metadata for a match to the project title, then grab the scraped GitHub bounty information from there.

I hope the primary maintainers of this event app don't look too poorly on this approach. It seems to break scoping conventions, a little, but it works! (Pardon, this is my first experience with `eleventy`, though it's similar to Microsoft Razor, but with JavaScript.)