### PR TITLE
remove test issue

### DIFF
--- a/projects/mitiq.md
+++ b/projects/mitiq.md
@@ -23,9 +23,6 @@ bounties:
   - name: Improve H2 example
     issue_num: 1094
     value: 100
-  - name: Test issue (maintainers only)
-    issue_num: 1298
-    value: 0  
 
 ---
 


### PR DESCRIPTION
Now that we've shown [completed](https://github.com/unitaryfund/unitaryhackdev/pull/82) bounties with strike-through text, we should remove the test issue so as to not cause any confusion.

If there is any more testing that needs to be done this should remain open until then.