### PR TITLE
Small change to tags of flamingpy

### DIFF
--- a/projects/flamingpy.md
+++ b/projects/flamingpy.md
@@ -7,8 +7,8 @@ date: 2022-06-02
 summary: A cross-platform Python library for efficient simulations of error correction in fault-tolerant quantum computers
 tags:
   - python
-  - quantum error correction
-  - fault tolerance
+  - quantum-error-correction
+  - fault-tolerance
 bounties:
   - name: Add local complementation function to EGraph class
     issue_num: 71

--- a/projects/flamingpy.md
+++ b/projects/flamingpy.md
@@ -7,7 +7,7 @@ date: 2022-06-02
 summary: A cross-platform Python library for efficient simulations of error correction in fault-tolerant quantum computers
 tags:
   - python
-  - quantum-error-correction
+  - error-correction
   - fault-tolerance
 bounties:
   - name: Add local complementation function to EGraph class


### PR DESCRIPTION
This is a small change in the tags yaml data of flamingy. Currently, the tag redirects to [404](https://unitaryhack.dev/tags/quantum%20error%20correction/). 