### PR TITLE
Slugify project titles on bounties page

### DIFF
--- a/_includes/components/bountylist.njk
+++ b/_includes/components/bountylist.njk
@@ -7,7 +7,7 @@
             <span class="project-card__emoji">{{ project.emoji }}</span>
             {% endif %}
             {% if project.title %}
-            <a  href="/projects/{{ project.title }}">{{ project.title }}</a>
+              <a  href="/projects/{{ project.title | slugify }}">{{ project.title }}</a>
             {% else %}
               Untitled
             {% endif %}

--- a/projects/quantumalgorithms.md
+++ b/projects/quantumalgorithms.md
@@ -5,6 +5,7 @@ project_url: "https://github.com/scinawa/quantumalgorithms.org"
 metaDescription: Learn the state-of-the-art quantum algorithms for machine learning
 date: 2022-04-01T00:00:00.000Z
 summary: Learn the state-of-the-art quantum algorithms for machine learning
+permalink: /projects/quantumalgorithms-org/
 tags:
   - quantum-algorithms
   - quantum-machine-learning


### PR DESCRIPTION
Sorry about he problem introduced in https://github.com/unitaryfund/unitaryhackdev/pull/94. Oddly enough the capitalization issues to not arise in local development. The problems with spaces (and other characters) in the URLs, however does appear locally.

fixes https://github.com/unitaryfund/unitaryhackdev/issues/98.
- Uses the eleventy `slugify` function to downcase the string, and replace spaces with hyphens.
- Adds a permalink to `quantumalgorithms.org` as `slugify` replaces a `.` with `-`.