### PR TITLE
ensure tags are slugified

### DIFF
--- a/_includes/components/projectlist.njk
+++ b/_includes/components/projectlist.njk
@@ -26,8 +26,8 @@
           <p class="tag-list">
             {% for tag in post.data.tags %}
               {%- if tag != "project" -%}
-                {% set tagUrl %}/tags/{{ tag }}/{% endset %}
-              <a class="project-card__tag tag" href="{{ tagUrl | url }}" rel="tag">{{ tag }}</a>
+                {% set tagUrl %}/tags/{{ tag | slugify }}/{% endset %}
+                <a class="project-card__tag tag" href="{{ tagUrl | url }}" rel="tag">{{ tag }}</a>
               {%- endif -%}
             {% endfor %}
           </p>

--- a/tag.njk
+++ b/tag.njk
@@ -11,7 +11,7 @@ pagination:
     - tagList
     - project
   addAllPagesToCollections: true
-permalink: /tags/{{ tag | slug }}/
+permalink: /tags/{{ tag | slugify }}/
 layout: layouts/base.njk
 renderData:
   title: "Tagged “{{ tag }}”"


### PR DESCRIPTION
fixes https://github.com/unitaryfund/unitaryhackdev/issues/100 by using `slugify` on the project list page, as well as upgrading from `slug` to `slugify` on the tag page (this second change would not be needed if not for the `c++` tag, which upon passing through `slug` remains `c++`, but `slugify` converts it to `c`).